### PR TITLE
Switch to used standard "Temporary Closure" instead of "Suspended."

### DIFF
--- a/meeting_guide/settings.py
+++ b/meeting_guide/settings.py
@@ -9,7 +9,7 @@ def get_display_flags():
     return getattr(
         settings,
         "WAGTAIL_MEETING_GUIDE_DISPLAY_FLAGS",
-        ["Men", "Women", "Wheelchair", "TempClosed"],
+        ["Men", "Women", "Wheelchair", "Temporary Closure"],
     )
 
 

--- a/meeting_guide/settings.py
+++ b/meeting_guide/settings.py
@@ -7,7 +7,9 @@ def get_display_flags():
     """
 
     return getattr(
-        settings, "WAGTAIL_MEETING_GUIDE_DISPLAY_FLAGS", ["Men", "Women", "Wheelchair"]
+        settings,
+        "WAGTAIL_MEETING_GUIDE_DISPLAY_FLAGS",
+        ["Men", "Women", "Wheelchair", "TempClosed"],
     )
 
 

--- a/meeting_guide/templates/meeting_guide/tags/meeting_guide.html
+++ b/meeting_guide/templates/meeting_guide/tags/meeting_guide.html
@@ -20,7 +20,6 @@ node-installed package and picked up by the Meeting Guide build process.
         strings: {
             en: {
                 types: {
-        		    TC: 'Suspended',
                     X: 'Wheelchair',
                 },
             },

--- a/meeting_guide/templatetags/meeting_guide.py
+++ b/meeting_guide/templatetags/meeting_guide.py
@@ -10,9 +10,11 @@ def meeting_guide(context):
     """
     Display the ReactJS drive Meeting Guide list.
     """
-    return {
+    settings = {
         "mapbox_key": context["mapbox_key"],
         "display_flags": ", ".join(
             [f"'{x}'" for x in get_display_flags()]
         ),
     }
+    print(settings)
+    return settings

--- a/meeting_guide/views.py
+++ b/meeting_guide/views.py
@@ -184,10 +184,12 @@ class MeetingsAPIView(MeetingsBaseView):
                 meeting.types.values_list("meeting_guide_code", flat=True)
             )
 
+            """
             if "TC" in meeting_types:
                 meeting_title = f"(SUSPENDED) {meeting_title}"
                 if len(meeting.video_conference_url):
                     meeting_types.remove("TC")
+            """
 
             district = meeting.district
             if len(district):


### PR DESCRIPTION
We've been using the "Suspended" tag for sometime - let's switch to "Temporary Closure" to be inline with the app and TSML.
